### PR TITLE
The name of the faction is added to the name of the building

### DIFF
--- a/src/components/SpaceHex.vue
+++ b/src/components/SpaceHex.vue
@@ -1,6 +1,6 @@
 <template>
   <g :id="`${hex}`">
-    <title>Coordinates: {{hex}}{{hex.data.planet !== 'e' ? `&#10;Planet: ${planetName(hex.data.planet)}`: ''}}{{hex.data.building ? `&#10;Building: ${buildingName(hex.data.building)}` : ''}}{{cost(hex) ? `&#10;Cost: ${cost(hex)}` : ''}}</title>
+    <title>Coordinates: {{hex}}{{hex.data.planet !== 'e' ? `&#10;Planet: ${planetName(hex.data.planet)}`: ''}}{{hex.data.building ? `&#10;Building: ${buildingName(hex.data.building, hex.data.player)}` : ''}}{{cost(hex) ? `&#10;Cost: ${cost(hex)}` : ''}}</title>
     <polygon :points="hexCorners.map(p => `${p.x},${p.y}`).join(' ')" :class="['spaceHex', {toSelect, highlighted: highlightedHexes.has(hex), qic: cost(hex).includes('q'), power: cost(hex).includes('pw')}]" @click='hexClick(hex)' />
     <text class="sector-name" v-if="isCenter">{{hex.data.sector[0] === 's' ? parseInt(hex.data.sector.slice(1)) : parseInt(hex.data.sector)}}</text>
     <Planet v-if="hex.data.planet !== 'e'" :planet='hex.data.planet' :faction='faction(hex.data.player)' />
@@ -78,8 +78,8 @@ export default class SpaceHex extends Vue {
     return factions.planet(this.faction(player));
   }
 
-  buildingName (building: BuildingEnum) {
-    return buildingName(building);
+  buildingName (building: BuildingEnum, player) {
+    return `${buildingName(building)} (${factions[this.faction(player)].name})`;
   }
 
   planetName (planet: PlanetEnum) {


### PR DESCRIPTION
In order to improve accessibility, we might not want to depend on just the colours for identification. As an example, I've added the faction that owns the building to the building name.