### PR TITLE
show own plnat type at top in faction wheel

### DIFF
--- a/src/components/FactionWheel.vue
+++ b/src/components/FactionWheel.vue
@@ -54,9 +54,10 @@ export default class FactionWheel extends Vue {
     const list = [Planet.Terra, Planet.Oxide, Planet.Volcanic, Planet.Desert, Planet.Swamp, Planet.Titanium, Planet.Ice, Planet.Gaia, Planet.Transdim];
     if (pos < 7) {
       const data = this.gameData;
-      const faction = data.player(data.currentPlayer).faction;
+      const player = this.$store.state.gaiaViewer.player ?? data.currentPlayer;
+      const faction = data.player(player).faction;
       if (faction != null) {
-        // player faction should be at the top
+        // own faction - or current players faction - should be at the top
         const planet = factions[faction].planet;
         const offset = list.indexOf(planet);
         return list[(pos + offset) % 7];

--- a/src/components/FactionWheel.vue
+++ b/src/components/FactionWheel.vue
@@ -3,14 +3,14 @@
     <circle :r=r fill=none />
     <g v-for="i in [0, 1, 2, 3, 4, 5, 6]" :key="i"
        :transform="`translate(${r*Math.sin((-180+i*51)*Math.PI/180)}, ${r*Math.cos((-180+i*51)*Math.PI/180)})`">
-      <circle :r="1" :class="['player-token', 'planet-fill', planet(i)]" />
+      <circle :r="1" :class="['planet-fill', planet(i)]" :style="`stroke-width: ${strokeWidth(i)}`" />
       <text
         :style="`font-size: 1.2px; text-anchor: middle; dominant-baseline: central; fill: ${planetFill(planet(i))}`">
         {{ remainingPlanets(planet(i)) }}
       </text>
     </g>
     <g v-for="i in [7, 8]" :key="i" :transform="`translate(${-2+(i-7)*4}, 5)`" >
-      <circle :r="1" :class="['player-token', 'planet-fill', planet(i)]" />
+      <circle :r="1" :class="['planet-fill', planet(i)]" />
       <text
         :style="`font-size: 1.2px; text-anchor: middle; dominant-baseline: central; fill: ${planetFill(planet(i))}`">
         {{ remainingPlanets(planet(i)) }}
@@ -22,22 +22,13 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import {Component} from 'vue-property-decorator';
-import Engine, {Planet} from '@gaia-project/engine';
+import { Component } from 'vue-property-decorator';
+import Engine, { factions, Planet } from '@gaia-project/engine';
 
 @Component
 export default class FactionWheel extends Vue {
-
   get r () {
     return 3;
-  }
-
-  get spacing () {
-    return 1.1;
-  }
-
-  angle (deg) {
-    return deg * 180 / Math.PI;
   }
 
   get gameData (): Engine {
@@ -50,8 +41,27 @@ export default class FactionWheel extends Vue {
       .length;
   }
 
+  strokeWidth (pos: number) {
+    const planet = this.planet(pos);
+    if (this.gameData.players.some(p => p.faction && factions[p.faction].planet === planet)) {
+      return "0.2px";
+    }
+
+    return "0.05px";
+  }
+
   planet (pos: number) {
     const list = [Planet.Terra, Planet.Oxide, Planet.Volcanic, Planet.Desert, Planet.Swamp, Planet.Titanium, Planet.Ice, Planet.Gaia, Planet.Transdim];
+    if (pos < 7) {
+      const data = this.gameData;
+      const faction = data.player(data.currentPlayer).faction;
+      if (faction != null) {
+        // player faction should be at the top
+        const planet = factions[faction].planet;
+        const offset = list.indexOf(planet);
+        return list[(pos + offset) % 7];
+      }
+    }
     return list[pos];
   }
 


### PR DESCRIPTION
- rotate faction wheel to show own player on top
- use a bigger stroke for planet types that are taken by players

this helps to see which planet types are most competed

![image](https://user-images.githubusercontent.com/2832627/107476633-86fd6b00-6b76-11eb-88e4-2ab4583b3f6e.png)
